### PR TITLE
Better support for image expansion in Hipchat

### DIFF
--- a/src/frinkiac.coffee
+++ b/src/frinkiac.coffee
@@ -34,7 +34,7 @@ encode = (str) ->
     '%' + c.charCodeAt(0).toString(16)
 
 getImageUrl = (episode, timestamp, caption) ->
-  "https://frinkiac.com/meme/#{episode}/#{timestamp}.jpg?lines=#{encode(caption)}"
+  "https://frinkiac.com/meme/#{episode}/#{timestamp}.jpg?lines=#{encode(caption)}#.jpg"
 
 getLongestWordLength = (words) ->
   longestWordLength = 0


### PR DESCRIPTION
Start appending a fake .jpg extension as an anchor on the url, because some chat clients (like Atlassian's Hipchat) are too stupid to expand images if they don't end in an image extension. As an anchor, it should be ignored by better chat clients.
